### PR TITLE
Fixed Error

### DIFF
--- a/Raspi_MotorHAT/Raspi_MotorHAT.py
+++ b/Raspi_MotorHAT/Raspi_MotorHAT.py
@@ -133,7 +133,7 @@ class Raspi_StepperMotor:
                 [0, 0, 1, 1],
                 [0, 0, 0, 1],
                 [1, 0, 0, 1] ]
-            coils = step2coils[self.currentstep/(self.MICROSTEPS/2)]
+            coils = step2coils[int(self.currentstep/(self.MICROSTEPS/2))]
 
         #print "coils state = " + str(coils)
         self.MC.setPin(self.AIN2, coils[0])


### PR DESCRIPTION
Error:
  File "/home/pi/Desktop/Segregation/Test/stepper/Raspi_MotorHAT/StepperTest.py", line 29, in <module>
    myStepper.step(200, Raspi_MotorHAT.FORWARD,  Raspi_MotorHAT.DOUBLE)
  File "/home/pi/Desktop/Segregation/Test/stepper/Raspi_MotorHAT/Raspi_MotorHAT/Raspi_MotorHAT.py", line 160, in step
    lateststep = self.oneStep(direction, stepstyle)
  File "/home/pi/Desktop/Segregation/Test/stepper/Raspi_MotorHAT/Raspi_MotorHAT/Raspi_MotorHAT.py", line 137, in oneStep
    coils = step2coils[self.currentstep/(self.MICROSTEPS/2)]
TypeError: list indices must be integers or slices, not float

This is happening because : "self.currentstep/(self.MICROSTEPS/2)" this division returns a float which the step2coils list can't understand as an index so convert that back to int so that it can be used as an index